### PR TITLE
update gnome runtime version to 42

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -1,7 +1,7 @@
 {
     "app-id": "info.portfolio_performance.PortfolioPerformance",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk11"


### PR DESCRIPTION
```
Info: runtime org.gnome.Platform branch 41 is end-of-life, with reason:

   The GNOME 41 runtime is no longer supported as of September 17, 2022. 
Please ask your application developer to migrate to a supported platform.
```

I've created another PR to update gnome to v43 but there are some issues with it so trying v42 to see if it works fine