### PR TITLE
Add IPC namespace sharing permission

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -9,6 +9,7 @@
     "command": "/app/jre/bin/PortfolioPerformance",
     "finish-args": [
         "--socket=x11",
+        "--share=ipc",
         "--share=network",
         "--filesystem=home",
         "--device=dri",


### PR DESCRIPTION
Add the `--share=ipc` argument to `finish-args`. The Flatpak
[documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html) says this is recommended for X11 programs so that they can use the MIT-SHM shared memory extension.