### PR TITLE
Overwrite directory `.eclipse` sandbox security

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,6 @@
 {
 	"only-arches": ["x86_64", "aarch64"],
-	"automerge-flathubbot-prs": true
+	"automerge-flathubbot-prs": true,
+        "finish-args": ["--share=ipc", "--socket=fallback-x11", "--socket=wayland", "--device=dri", "--filesystem=~/.eclipse"
+]	
 }


### PR DESCRIPTION
Flatpack require dedicated access for directory `.eclipse ` due to the sandbox update process https://github.com/buchen/portfolio/issues/3418#issuecomment-1606259200