### PR TITLE
Updated Github URLs are transferring the repository to portfolio-performance

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -53,7 +53,7 @@
                     "sha256": "745f30e49c94372a4bc8fa850ba7562c0acf8f292fcbd04f6671d8b3a9726103",
                     "x-checker-data": {
                         "type": "json",
-                        "url": "https://api.github.com/repos/buchen/portfolio/releases/latest",
+                        "url": "https://api.github.com/repos/portfolio-performance/portfolio/releases/latest",
                         "version-query": ".tag_name",
                         "url-query": ".assets[] | select(.name==\"PortfolioPerformance-\" + $version + \"-linux.gtk.x86_64.tar.gz\") | .browser_download_url"
                     }
@@ -67,7 +67,7 @@
                     "sha256": "df8cb1898059f7f446fc907c8e3d0199cfed66cd759d4dc1c43f9d52f923292f",
                     "x-checker-data": {
                         "type": "json",
-                        "url": "https://api.github.com/repos/buchen/portfolio/releases/latest",
+                        "url": "https://api.github.com/repos/portfolio-performance/portfolio/releases/latest",
                         "version-query": ".tag_name",
                         "url-query": ".assets[] | select(.name==\"PortfolioPerformance-\" + $version + \"-linux.gtk.aarch64.tar.gz\") | .browser_download_url"
                     }

--- a/info.portfolio_performance.PortfolioPerformance.metainfo.xml
+++ b/info.portfolio_performance.PortfolioPerformance.metainfo.xml
@@ -104,7 +104,7 @@
 
   <developer_name>Andreas Buchen</developer_name>
 
-  <url type="bugtracker">https://github.com/buchen/portfolio/issues</url>
+  <url type="bugtracker">https://github.com/portfolio-performance/portfolio/issues</url>
 
   <!--FIXME: where to donate to the application-->
   <!-- <url type="donation">http://www.homepage.com/donation.html</url> -->
@@ -113,7 +113,7 @@
 
   <url type="translate">https://poeditor.com/join/project?hash=4lYKLpEWOY</url>
 
-  <url type="vcs-browser">https://github.com/buchen/portfolio</url>
+  <url type="vcs-browser">https://github.com/portfolio-performance/portfolio</url>
 
   <!--FIXME: this is optional, but recommended-->
   <!-- <update_contact>upstream-contact_at_email.com</update_contact> -->


### PR DESCRIPTION
After 11 years Portfolio Performance has outgrown a personal Github account.
The repository is now transferred (see portfolio-performance/portfolio#3458).
This change updated the URLs in the Flatpak metadata