### PR TITLE
Update org.gnome.platform from 43 to 44

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -1,7 +1,7 @@
 {
     "app-id": "info.portfolio_performance.PortfolioPerformance",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk17"


### PR DESCRIPTION
Bug
https://github.com/portfolio-performance/portfolio/issues/3565

[Bump runtime to 44](https://github.com/flathub/org.gnome.gitg/commit/d63ff070b9660ad0637bc56cee1d2ab9cecb57dc)