### PR TITLE
Update: info.portfolio_performance.PortfolioPerformance.json

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -1,7 +1,7 @@
 {
     "app-id": "info.portfolio_performance.PortfolioPerformance",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk17"


### PR DESCRIPTION
- bump runtime to 45 to fix:

Info: runtime org.gnome.Platform branch 44 is end-of-life, with reason:
   The GNOME 44 runtime is no longer supported as of March 20, 2024.
Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   info.portfolio_performance.PortfolioPerformance