### PR TITLE
Update to Java 21

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -4,7 +4,7 @@
     "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk17"
+        "org.freedesktop.Sdk.Extension.openjdk21"
     ],
     "command": "PortfolioPerformance",
     "finish-args": [
@@ -16,14 +16,14 @@
         "--env=PATH=/app/bin:/app/jre/bin:/usr/bin"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/openjdk17/bin"
+        "append-path": "/usr/lib/sdk/openjdk21/bin"
     },
     "modules": [
         {
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk17/install.sh"
+                "/usr/lib/sdk/openjdk21/install.sh"
             ]
         },
         {


### PR DESCRIPTION
With the **next** version (>= 0.72.0), Portfolio Performance will require Java 21.

This pull request updates the dependencies from openjdk17 to openjdk21.