### PR TITLE
Allow Wayland access and update to org.gnome.Platform 49

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -8,7 +8,8 @@
     ],
     "command": "PortfolioPerformance",
     "finish-args": [
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--share=ipc",
         "--share=network",
         "--filesystem=home",


### PR DESCRIPTION
The Eclipse flatpak has already made both these changes [1][2]. I've tested
that Portfolio Performance works fine under Wayland.

[1] https://github.com/flathub/org.eclipse.Java/commit/55a106471ca6550340dc4b5e696861773e061e5f
[2] https://github.com/flathub/org.eclipse.Java/commit/71fef864218d8a9520145e10c7cf325011582216