### PR TITLE
native wayland support

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -8,7 +8,8 @@
     ],
     "command": "PortfolioPerformance",
     "finish-args": [
-        "--socket=x11",
+        "--socket=fallback-x11",
+        "--socket=wayland",
         "--share=ipc",
         "--share=network",
         "--filesystem=home",


### PR DESCRIPTION
On XWayland+Gnome, the scaling is a bit messed up. Turns out that Eclipse (which is used by Portfolio) works perfectly well under Wayland. With both X11 and Wayland exposed to the app, it defaults to Wayland (tested both via a visual check and via `xwininfo -tree -root`). This change was tested via a [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal) override.